### PR TITLE
fix openssl deprecated warning message for Ruby 2.4+

### DIFF
--- a/lib/encrypted_strings/symmetric_cipher.rb
+++ b/lib/encrypted_strings/symmetric_cipher.rb
@@ -93,7 +93,7 @@ module EncryptedStrings
     
     private
       def build_cipher(type) #:nodoc:
-        cipher = OpenSSL::Cipher::Cipher.new(algorithm).send(type)
+        cipher = OpenSSL::Cipher.new(algorithm).send(type)
         cipher.pkcs5_keyivgen(password)
         cipher
       end


### PR DESCRIPTION
Ora: https://ora.pm/project/11168/list/37043/task/548192
Fix openssl deprecated warning message for Ruby 2.4+